### PR TITLE
Removed Laravel "v"

### DIFF
--- a/resources/views/filament-versions.blade.php
+++ b/resources/views/filament-versions.blade.php
@@ -5,7 +5,7 @@
     x-data
     x-show="$store.sidebar.isOpen">
     <ul class="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <li class="flex-shrink-0">Laravel v{{ $versions['laravel'] }}</li>
+        <li class="flex-shrink-0">Laravel {{ $versions['laravel'] }}</li>
         <li class="flex-shrink-0">PHP v{{ $versions['php'] }}</li>
         <li class="flex-shrink-0">Filament {{ $versions['filament'] }}</li>
         @if (FilamentVersions\Facades\FilamentVersions::getItems())


### PR DESCRIPTION
Laravel's version already includes the "v" just removing the duplicate.