### PR TITLE
Fix: Dashboard widget spacing & centering

### DIFF
--- a/resources/views/widget.blade.php
+++ b/resources/views/widget.blade.php
@@ -4,7 +4,7 @@
             {{ __('filament-versions::widget.title') }}
         </x-slot>
 
-        <dl class="flex flex-wrap items-center text-center gap-y-4">
+        <dl class="flex flex-wrap justify-center items-center text-center gap-y-4 gap-x-4">
             @foreach ($versions as $version)
                 <div class="w-1/3">
                     <dt class="text-2xl font-bold text-primary-500">{{ str($version['version'])->ltrim('v') }}</dt>


### PR DESCRIPTION
On a default install using the dashboard widget on latest Laravel & Livewire (versions in screenshots), I noticed there is not adequate spacing between the versions nor centering. This is after including the tailwind config and building - and confirmed because I first tested this by manually editing the CSS on my page.

Before:

<img width="543" alt="Screenshot 2023-08-10 at 21 32 11" src="https://github.com/nikspyratos/filament-versions/assets/17888779/5615a0c4-8553-481e-9018-5090a47a47e7">

---

After:

<img width="562" alt="Screenshot 2023-08-10 at 21 33 39" src="https://github.com/nikspyratos/filament-versions/assets/17888779/0d007f42-5de3-4fd5-8f8e-51dc450e0180">
